### PR TITLE
Add Italy country support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The SDK supports various countries including:
 - France (`Countries::FRANCE`)
 - Germany (`Countries::GERMANY`)
 - United States (`Countries::UNITED_STATES_OF_AMERICA`)
+- Italy (`Countries::ITALY`)
 - Demo mode (`Countries::DEMO`)
 
 ## Development Mode

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "minimum-stability": "stable",
     "license": "MIT",
-    "version": "3.0.7",
+    "version": "3.0.8",
     "require": {
         "league/oauth2-client": "^2.6"
     },

--- a/src/Countries.php
+++ b/src/Countries.php
@@ -26,6 +26,8 @@ class Countries {
   const UNITED_STATES_OF_AMERICA_EIGHT = "us8";
   const UNITED_STATES_OF_AMERICA_NINE = "us9";
   const UNITED_STATES_OF_AMERICA_TEN = "us10";
+  const ITALY = "it";
+  const ITALY_TWO = "it2";
   const DEMO = "DEMO";
 
 

--- a/src/OAuth.php
+++ b/src/OAuth.php
@@ -27,6 +27,8 @@ class OAuth
         Countries::UNITED_STATES_OF_AMERICA_EIGHT,
         Countries::UNITED_STATES_OF_AMERICA_NINE,
         Countries::UNITED_STATES_OF_AMERICA_TEN,
+        Countries::ITALY,
+        Countries::ITALY_TWO,
         Countries::DEMO,
     ];
 

--- a/src/OAuthV1.php
+++ b/src/OAuthV1.php
@@ -31,6 +31,7 @@ class OAuthV1
         Countries::FRANCE,
         Countries::GERMANY,
         Countries::UNITED_STATES_OF_AMERICA,
+        Countries::ITALY,
         Countries::DEMO,
     ];
 

--- a/src/OAuthV2.php
+++ b/src/OAuthV2.php
@@ -31,6 +31,7 @@ class OAuthV2
         Countries::FRANCE,
         Countries::GERMANY,
         Countries::UNITED_STATES_OF_AMERICA,
+        Countries::ITALY,
         Countries::DEMO,
     ];
 


### PR DESCRIPTION
Added Italy (IT) and Italy Two (IT2) country constants and integration across OAuth, OAuthV1, and OAuthV2 classes. Updated version to 3.0.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)