### PR TITLE
Add webhook notification level support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Methods::ID_SCAN_FACE_MATCH
 Methods::EMAIL
 ```
 
+### Webhook Notification Levels
+
+Available webhook notification levels:
+```php
+Webhook::MINIMUM_NOTIFICATION_LEVEL
+Webhook::METHOD_EXHAUSTED_NOTIFICATION_LEVEL
+Webhook::DETAILED_NOTIFICATION_LEVEL
+```
+
 ### Starting Verification (OAuthV2)
 
 ```php
@@ -151,6 +160,7 @@ Here's a complete example of implementing age verification:
 use VerifyMyAge\OAuthV2;
 use VerifyMyAge\Countries;
 use VerifyMyAge\Methods;
+use VerifyMyAge\Webhook;
 
 // Initialize the OAuth client
 $oauth = new OAuthV2(
@@ -168,7 +178,8 @@ $verificationResult = $oauth->getStartVerificationUrl(
     method: Methods::ID_SCAN,
     businessSettingsId: 'your-business-id',
     externalUserId: 'user-123',
-    webhook: 'https://your-app.com/webhook'
+    webhook: 'https://your-app.com/webhook',
+    webhookNotificationLevel: Webhook::DETAILED_NOTIFICATION_LEVEL,
 );
 
 // Handle the verification response

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ $result = $oauth->getStartVerificationUrl(
     externalUserId: 'user-123',
     verificationId: 'verification-123',
     webhook: 'https://your-webhook.com/callback',
+    webhookNotificationLevel: Webhook::DETAILED_NOTIFICATION_LEVEL,
     stealth: false,
     userInfo: [
         'email' => 'user@example.com'

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "minimum-stability": "stable",
     "license": "MIT",
-    "version": "3.0.8",
+    "version": "3.0.9",
     "require": {
         "league/oauth2-client": "^2.6"
     },

--- a/src/OAuthV2.php
+++ b/src/OAuthV2.php
@@ -35,6 +35,12 @@ class OAuthV2
         Countries::DEMO,
     ];
 
+    const WEBHOOK_NOTIFICATION_LEVELS = [
+        Webhook::MINIMUM_NOTIFICATION_LEVEL,
+        Webhook::METHOD_EXHAUSTED_NOTIFICATION_LEVEL,
+        Webhook::DETAILED_NOTIFICATION_LEVEL,
+    ];
+
     public function __construct($clientID, $clientSecret, $redirectURL)
     {
         $this->clientID = $clientID;
@@ -62,6 +68,10 @@ class OAuthV2
 
         if($method && !in_array($method, static::METHODS)){
             throw new \Exception("Invalid method: ". $method);
+        }
+
+        if ($webhookNotificationLevel && !in_array($webhookNotificationLevel, static::WEBHOOK_NOTIFICATION_LEVELS)) {
+            throw new \Exception("Invalid webhook notification level: ". $webhookNotificationLevel);
         }
     
         try {

--- a/src/OAuthV2.php
+++ b/src/OAuthV2.php
@@ -55,7 +55,7 @@ class OAuthV2
     /**
      * Do a post with HMAC authorization to VerifyMy OAuthV2 and return response from service.
      */
-    public function getStartVerificationUrl(string $country, string $method="", string $businessSettingsId="", string $externalUserId="", string $verificationId="", string $webhook="",bool $stealth=false, array $userInfo=array()){
+    public function getStartVerificationUrl(string $country, string $method="", string $businessSettingsId="", string $externalUserId="", string $verificationId="", string $webhook="", string $webhookNotificationLevel="", bool $stealth=false, array $userInfo=array()){
         if (!in_array($country, static::COUNTRIES)) {
             throw new \Exception("Invalid country: " . $country);
         }
@@ -74,6 +74,7 @@ class OAuthV2
                 "verification_id"       => $verificationId,
                 "redirect_url"          => $this->redirectURL,
                 "webhook"               => $webhook,
+                "webhook_notification_level" => $webhookNotificationLevel,
             ];
             if (count($userInfo)) {
                 $body['user_info'] = $this->provider()->getUserInfoEncoded($userInfo);

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace VerifyMyAge;
+
+class Webhook {
+    const MINIMUM_NOTIFICATION_LEVEL = "minimum";
+    const METHOD_EXHAUSTED_NOTIFICATION_LEVEL = "method_exhausted";
+    const DETAILED_NOTIFICATION_LEVEL = "detailed";
+}


### PR DESCRIPTION
Added webhookNotificationLevel parameter to getStartVerificationUrl method with three notification levels (minimum, method_exhausted, detailed) defined in new Webhook class. Updated documentation and bumped version to 3.0.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)