### PR TITLE
Add OAuthV3 with API v3 support (NMP-4715)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ A PHP SDK for integrating with VerifyMyAge's verification service. This library 
 - [Installation](#installation)
 - [Features](#features)
 - [Usage](#usage)
-  - [Basic Setup](#basic-setup)
-  - [Available Methods](#available-methods)
+  - [SDK Versions](#sdk-versions)
   - [Verification Methods](#verification-methods)
-  - [Verification Status](#verification-status-oauthv1--oauthv2)
+  - [Webhook Notification Levels](#webhook-notification-levels)
   - [Supported Countries](#supported-countries)
-- [Examples](#examples)
+- [OAuthV3 (Recommended)](#oauthv3-recommended)
+  - [Start a Verification](#start-a-verification)
+  - [Get Verification Status](#get-verification-status)
+  - [Manage Allowed Redirect URLs](#manage-allowed-redirect-urls)
+- [OAuthV2](#oauthv2)
+- [OAuthV1 / OAuth (Legacy)](#oauthv1--oauth-legacy)
 - [Development Mode](#development-mode)
+- [Error Handling](#error-handling)
+- [Security Considerations](#security-considerations)
 
 ## Installation
 
@@ -22,112 +28,45 @@ composer require verifymyagecouk/verifymyage-oauth
 
 ## Features
 
-- Authentication flow
+- API v3 support with direct HMAC authentication
 - Multiple verification methods
 - Support for various countries
 - Sandbox environment for testing
-- HMAC authentication
 - User data encryption
 
 ## Usage
 
-### Basic Setup
+### SDK Versions
 
-```php
-use VerifyMyAge\OAuth;
-
-// Initialize the OAuth client
-$oauth = new OAuth(
-    'your-client-id',
-    'your-client-secret',
-    'your-redirect-url'
-);
-
-// For development/testing, use sandbox mode
-$oauth->useSandbox();
-```
-
-### Available Methods
-
-The SDK provides three different versions of the OAuth implementation:
-
-1. **OAuth (Legacy)**:
-```php
-use VerifyMyAge\OAuth;
-$oauth = new OAuth($clientId, $clientSecret, $redirectUrl);
-```
-
-2. **OAuthV1**: 
-```php
-use VerifyMyAge\OAuthV1;
-$oauth = new OAuthV1($clientId, $clientSecret, $redirectUrl);
-```
-
-3. **OAuthV2** (Recommended):
-```php
-use VerifyMyAge\OAuthV2;
-$oauth = new OAuthV2($clientId, $clientSecret, $redirectUrl);
-```
+| Class | API Version | Status |
+|-------|-------------|--------|
+| `OAuthV3` | v3 | **Recommended** |
+| `OAuthV2` | v2 | Maintained |
+| `OAuthV1` | v1 | Maintained |
+| `OAuth` | Legacy | Legacy |
 
 ### Verification Methods
 
-Available verification methods:
 ```php
-Methods::AGE_ESTIMATION
-Methods::CREDIT_CARD
-Methods::ID_SCAN
-Methods::ID_SCAN_FACE_MATCH
-Methods::EMAIL
+use VerifyMyAge\Methods;
+
+Methods::AGE_ESTIMATION     // "AgeEstimation"
+Methods::CREDIT_CARD        // "CreditCard"
+Methods::DOUBLE_BLIND       // "DoubleBlind"  — v3 only
+Methods::EMAIL              // "Email"
+Methods::ID_SCAN            // "IDScan"
+Methods::ID_SCAN_FACE_MATCH // "IDScanFaceMatch"
 ```
 
 ### Webhook Notification Levels
 
-Available webhook notification levels:
 ```php
-Webhook::MINIMAL_NOTIFICATION_LEVEL
-Webhook::METHOD_EXHAUSTED_NOTIFICATION_LEVEL
-Webhook::DETAILED_NOTIFICATION_LEVEL
-```
+use VerifyMyAge\Webhook;
 
-### Starting Verification (OAuthV2)
-
-```php
-$result = $oauth->getStartVerificationUrl(
-    country: Countries::UNITED_KINGDOM,
-    method: Methods::ID_SCAN,
-    businessSettingsId: 'your-business-settings-id',
-    externalUserId: 'user-123',
-    verificationId: 'verification-123',
-    webhook: 'https://your-webhook.com/callback',
-    webhookNotificationLevel: Webhook::DETAILED_NOTIFICATION_LEVEL,
-    stealth: false,
-    userInfo: [
-        'email' => 'user@example.com'
-        // Additional user information
-    ]
-);
-```
-
-### Handling the OAuth Flow
-
-1. **Generate Authorization URL**:
-```php
-$authUrl = $oauth->redirectURL(
-    country: Countries::UNITED_KINGDOM,
-    method: Methods::ID_SCAN
-);
-```
-
-2. **Exchange Code for Token**:
-
-After the user completes the verification process with us, we will redirect the user back to you
-using your redirect URL provided to us in the first step, we will keep all the query strings you've sent and also
-add two new ones, First as **code** and Second as **verification_id**.
-The **code** must be used in this function, so we can authenticate your request and identify the verification 
-that you want to get the result.
-
-```php
-$token = $oauth->exchangeCodeByToken($code);
+Webhook::MINIMAL_NOTIFICATION_LEVEL              // "minimal"           — v2 & v3
+Webhook::DETAILED_NOTIFICATION_LEVEL             // "detailed"          — v2 & v3
+Webhook::METHOD_EXHAUSTED_NOTIFICATION_LEVEL     // "method_exhausted"  — v2
+Webhook::METHOD_EXHAUSTED_V3_NOTIFICATION_LEVEL  // "method-exhausted"  — v3
 ```
 
 ### Supported Countries
@@ -145,78 +84,189 @@ The SDK supports various countries including:
 - Italy (`Countries::ITALY`)
 - Demo mode (`Countries::DEMO`)
 
-## Development Mode
+---
 
-For testing and development, use the sandbox environment:
+## OAuthV3 (Recommended)
+
+OAuthV3 targets the `/api/v3/verifications` endpoints and uses HMAC authentication directly — there is no OAuth2 code-exchange step. After the user completes verification they are redirected to your `redirect_url` with a `verification_id` query parameter; use `getVerification()` to retrieve the result.
+
+### Start a Verification
 
 ```php
+use VerifyMyAge\OAuthV3;
+use VerifyMyAge\Countries;
+use VerifyMyAge\Methods;
+use VerifyMyAge\Webhook;
+
+$oauth = new OAuthV3(
+    'your-api-key',
+    'your-api-secret',
+    'https://your-app.com/callback'
+);
+
+// Optional: use sandbox for development
 $oauth->useSandbox();
+
+$result = $oauth->getStartVerificationUrl(
+    country: Countries::UNITED_KINGDOM,
+    method: Methods::ID_SCAN,                                   // optional
+    businessSettingsId: 'your-business-settings-id',            // optional
+    externalUserId: 'user-123',                                 // optional
+    webhook: 'https://your-app.com/webhook',                    // optional
+    webhookNotificationLevel: Webhook::DETAILED_NOTIFICATION_LEVEL, // optional
+    userInfo: ['email' => 'user@example.com'],                  // optional
+);
+
+// Instant approval — no user interaction needed
+if ($result['verification_status'] === 'approved') {
+    // User is already approved
+}
+
+// User interaction required — redirect them to the verification URL
+if (isset($result['start_verification_url'])) {
+    header('Location: ' . $result['start_verification_url']);
+    exit;
+}
 ```
 
-This will direct all requests to the sandbox API endpoint.
+### Get Verification Status
 
-## Complete Example
-
-Here's a complete example of implementing age verification:
+After the user completes verification they are redirected to your callback URL with `?verification_id=abc123`. Use that ID to fetch the result:
 
 ```php
-<?php
+$verification = $oauth->getVerification($verificationId);
 
+// Possible statuses: started | pending | approved | failed | expired
+echo $verification['status'];
+```
+
+### Manage Allowed Redirect URLs
+
+```php
+// List all registered redirect URLs for this account
+$urls = $oauth->getAllowedRedirects();
+
+// Append new URLs (does not replace the existing list)
+$oauth->addAllowedRedirects([
+    'https://your-app.com/callback',
+    'https://your-app.com/alt-callback',
+]);
+```
+
+---
+
+## OAuthV2
+
+OAuthV2 targets the `/v2/auth/start` endpoint. After verification the user is redirected with a `code` and `verification_id`; exchange the code for a token to retrieve user data.
+
+```php
 use VerifyMyAge\OAuthV2;
 use VerifyMyAge\Countries;
 use VerifyMyAge\Methods;
 use VerifyMyAge\Webhook;
 
-// Initialize the OAuth client
 $oauth = new OAuthV2(
-    clientID: 'your-client-id',
-    clientSecret: 'your-client-secret',
-    redirectURL: 'https://your-app.com/callback'
+    'your-client-id',
+    'your-client-secret',
+    'https://your-app.com/callback'
 );
 
-// Use sandbox for development
-$oauth->useSandbox();
+$oauth->useSandbox(); // optional
 
-// Start verification process
-$verificationResult = $oauth->getStartVerificationUrl(
+// Start verification
+$result = $oauth->getStartVerificationUrl(
     country: Countries::UNITED_KINGDOM,
     method: Methods::ID_SCAN,
     businessSettingsId: 'your-business-id',
     externalUserId: 'user-123',
+    verificationId: '',
     webhook: 'https://your-app.com/webhook',
     webhookNotificationLevel: Webhook::DETAILED_NOTIFICATION_LEVEL,
+    stealth: false,
+    userInfo: ['email' => 'user@example.com'],
 );
 
-// Handle the verification response
-if (isset($verificationResult['verification_url'])) {
-    // Redirect user to verification URL
-    header('Location: ' . $verificationResult['verification_url']);
+if (isset($result['start_verification_url'])) {
+    header('Location: ' . $result['start_verification_url']);
     exit;
 }
+
+// On callback: exchange the code for a token
+$token = $oauth->exchangeCodeByToken($_GET['code']);
+
+// Retrieve user/verification data
+$user = $oauth->user($token);
 ```
 
-### Verification Status (OAuthV1 & OAuthV2)
+---
 
-For detailed information about how to check the verification status, please refer to the official documentation:
-[Verification Status Documentation](https://docs.verifymyage.com/docs/adult/authorisation/#retrieve-verification-status)
+## OAuthV1 / OAuth (Legacy)
 
-## Security Considerations
+```php
+use VerifyMyAge\OAuthV1;
 
-- Always use HTTPS for redirect URLs
-- Keep your client credentials secure
-- Validate all user input
-- Implement proper error handling
-- Use webhook validation for callbacks
+$oauth = new OAuthV1($clientId, $clientSecret, $redirectUrl);
+
+$result = $oauth->getStartVerificationUrl(
+    country: Countries::UNITED_KINGDOM,
+    method: Methods::ID_SCAN,
+);
+
+// On callback: exchange the code for a token
+$token = $oauth->exchangeCodeByToken($_GET['code']);
+```
+
+The legacy `OAuth` class uses the OAuth2 authorization-code redirect flow:
+
+```php
+use VerifyMyAge\OAuth;
+
+$oauth = new OAuth($clientId, $clientSecret, $redirectUrl);
+
+// Redirect user to the VerifyMyAge authorization page
+$authUrl = $oauth->redirectURL(Countries::UNITED_KINGDOM, Methods::ID_SCAN);
+header('Location: ' . $authUrl);
+exit;
+
+// On callback: exchange the code for a token
+$token = $oauth->exchangeCodeByToken($_GET['code']);
+$user  = $oauth->user($token);
+```
+
+---
+
+## Development Mode
+
+All SDK versions support sandbox mode. Use it during development to avoid affecting production data:
+
+```php
+$oauth->useSandbox();
+```
+
+Sandbox endpoint: `https://oauth.sandbox.verifymyage.com`  
+Production endpoint: `https://oauth.verifymyage.com`
+
+---
 
 ## Error Handling
 
-The SDK throws exceptions for invalid inputs or API errors. Always wrap API calls in try-catch blocks:
+The SDK throws `\Exception` for invalid inputs and API errors. API errors include the HTTP status code in the exception message as JSON:
 
 ```php
 try {
-    $result = $oauth->getStartVerificationUrl(...);
+    $result = $oauth->getStartVerificationUrl(country: Countries::UNITED_KINGDOM);
 } catch (\Exception $e) {
-    // Handle the error appropriately
+    $error = json_decode($e->getMessage(), true);
+    // $error['code'] contains the HTTP status code (for API errors)
     error_log($e->getMessage());
 }
 ```
+
+---
+
+## Security Considerations
+
+- Always use HTTPS for redirect URLs and webhook endpoints
+- Keep your API credentials secure and out of version control
+- Validate the `verification_id` received in callbacks before using it
+- Use webhook signature verification where available

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "minimum-stability": "stable",
     "license": "MIT",
-    "version": "3.1.3",
+    "version": "3.2.0",
     "require": {
         "league/oauth2-client": "^2.6"
     },

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -5,7 +5,8 @@ namespace VerifyMyAge;
 class Methods {
   const AGE_ESTIMATION      = "AgeEstimation";
   const CREDIT_CARD         = "CreditCard";
+  const DOUBLE_BLIND        = "DoubleBlind";
+  const EMAIL               = "Email";
   const ID_SCAN             = "IDScan";
   const ID_SCAN_FACE_MATCH  = "IDScanFaceMatch";
-  const EMAIL               = "Email";
 }

--- a/src/OAuthV3.php
+++ b/src/OAuthV3.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace VerifyMyAge;
+
+use GuzzleHttp\Client;
+
+/**
+ * VerifyMyAge OAuth - Age Assurance SDK (API v3)
+ */
+class OAuthV3
+{
+    private $clientID;
+
+    private $clientSecret;
+
+    private $redirectURL;
+
+    private $currentProvider;
+
+    const METHODS = [
+        Methods::AGE_ESTIMATION,
+        Methods::CREDIT_CARD,
+        Methods::DOUBLE_BLIND,
+        Methods::EMAIL,
+        Methods::ID_SCAN,
+        Methods::ID_SCAN_FACE_MATCH,
+    ];
+
+    const COUNTRIES = [
+        Countries::AUSTRALIA,
+        Countries::BRAZIL,
+        Countries::SPAIN,
+        Countries::UNITED_KINGDOM,
+        Countries::FRANCE,
+        Countries::GERMANY,
+        Countries::IRELAND,
+        Countries::ITALY,
+        Countries::UNITED_STATES_OF_AMERICA,
+        Countries::INDONESIA,
+        Countries::DEMO,
+    ];
+
+    const WEBHOOK_NOTIFICATION_LEVELS = [
+        Webhook::MINIMAL_NOTIFICATION_LEVEL,
+        Webhook::METHOD_EXHAUSTED_V3_NOTIFICATION_LEVEL,
+        Webhook::DETAILED_NOTIFICATION_LEVEL,
+    ];
+
+    public function __construct($clientID, $clientSecret, $redirectURL)
+    {
+        $this->clientID       = $clientID;
+        $this->clientSecret   = $clientSecret;
+        $this->redirectURL    = $redirectURL;
+        $this->currentProvider = null;
+    }
+
+    /**
+     * Switch to the sandbox environment for testing.
+     */
+    public function useSandbox()
+    {
+        $this->provider()->useSandbox();
+    }
+
+    /**
+     * Start a new verification session (POST /api/v3/verifications).
+     *
+     * Returns the API response array. When the user can be instantly approved the
+     * response contains only `verification_id` and `verification_status`. When user
+     * interaction is required it also contains `start_verification_url`.
+     */
+    public function getStartVerificationUrl(
+        string $country,
+        string $method = "",
+        string $businessSettingsId = "",
+        string $externalUserId = "",
+        string $webhook = "",
+        string $webhookNotificationLevel = "",
+        array $userInfo = []
+    ) {
+        if (!in_array($country, static::COUNTRIES)) {
+            throw new \Exception("Invalid country: " . $country);
+        }
+
+        if ($method && !in_array($method, static::METHODS)) {
+            throw new \Exception("Invalid method: " . $method);
+        }
+
+        if ($webhookNotificationLevel && !in_array($webhookNotificationLevel, static::WEBHOOK_NOTIFICATION_LEVELS)) {
+            throw new \Exception("Invalid webhook notification level: " . $webhookNotificationLevel);
+        }
+
+        try {
+            $body = array_filter([
+                "redirect_url"               => $this->redirectURL,
+                "country"                    => $country,
+                "method"                     => $method,
+                "business_settings_id"       => $businessSettingsId,
+                "external_user_id"           => $externalUserId,
+                "webhook"                    => $webhook,
+                "webhook_notification_level" => $webhookNotificationLevel,
+            ], fn($v) => $v !== null && $v !== '');
+
+            if (count($userInfo)) {
+                $body['user_info'] = $this->provider()->getUserInfoEncoded($userInfo);
+            }
+
+            $bodyEncoded   = json_encode($body);
+            $authorization = $this->provider()->generateHMACAuthorization($bodyEncoded);
+            $url           = $this->provider()->getStartVerificationUrl();
+            $client        = new Client();
+            $response      = $client->request('POST', $url, [
+                'headers' => [
+                    'Authorization' => $authorization,
+                    'Content-Type'  => 'application/json',
+                ],
+                'body' => $bodyEncoded,
+            ]);
+
+            return json_decode($response->getBody()->getContents(), true);
+
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $response   = $e->getResponse();
+            $statusCode = $response->getStatusCode();
+            $jsonObject = json_decode($response->getBody()->getContents(), true);
+            $jsonObject['code'] = $statusCode;
+            throw new \Exception(json_encode($jsonObject));
+        }
+    }
+
+    /**
+     * Retrieve the current status and details of a verification (GET /api/v3/verifications/{id}).
+     *
+     * Call this after the user is redirected back to your redirect URL with a
+     * `verification_id` query parameter to obtain the final result.
+     */
+    public function getVerification(string $verificationId)
+    {
+        try {
+            $url       = $this->provider()->getVerificationUrl($verificationId);
+            $uriPath   = parse_url($url, PHP_URL_PATH);
+            $authorization = $this->provider()->generateHMACAuthorizationForGet($uriPath);
+            $client    = new Client();
+            $response  = $client->request('GET', $url, [
+                'headers' => [
+                    'Authorization' => $authorization,
+                    'Content-Type'  => 'application/json',
+                ],
+            ]);
+
+            return json_decode($response->getBody()->getContents(), true);
+
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $response   = $e->getResponse();
+            $statusCode = $response->getStatusCode();
+            $jsonObject = json_decode($response->getBody()->getContents(), true);
+            $jsonObject['code'] = $statusCode;
+            throw new \Exception(json_encode($jsonObject));
+        }
+    }
+
+    /**
+     * Get all allowed redirect URLs registered for this account (GET /api/v3/allowed-redirects).
+     */
+    public function getAllowedRedirects()
+    {
+        try {
+            $url       = $this->provider()->getAllowedRedirectsUrl();
+            $uriPath   = parse_url($url, PHP_URL_PATH);
+            $authorization = $this->provider()->generateHMACAuthorizationForGet($uriPath);
+            $client    = new Client();
+            $response  = $client->request('GET', $url, [
+                'headers' => [
+                    'Authorization' => $authorization,
+                    'Content-Type'  => 'application/json',
+                ],
+            ]);
+
+            return json_decode($response->getBody()->getContents(), true);
+
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $response   = $e->getResponse();
+            $statusCode = $response->getStatusCode();
+            $jsonObject = json_decode($response->getBody()->getContents(), true);
+            $jsonObject['code'] = $statusCode;
+            throw new \Exception(json_encode($jsonObject));
+        }
+    }
+
+    /**
+     * Append one or more redirect URLs to the allowed list (PUT /api/v3/allowed-redirects).
+     *
+     * This appends to the existing list — it does not replace it.
+     * All URLs must use HTTPS.
+     */
+    public function addAllowedRedirects(array $urls)
+    {
+        try {
+            $bodyEncoded   = json_encode($urls);
+            $authorization = $this->provider()->generateHMACAuthorization($bodyEncoded);
+            $url           = $this->provider()->getAllowedRedirectsUrl();
+            $client        = new Client();
+            $response      = $client->request('PUT', $url, [
+                'headers' => [
+                    'Authorization' => $authorization,
+                    'Content-Type'  => 'application/json',
+                ],
+                'body' => $bodyEncoded,
+            ]);
+
+            return json_decode($response->getBody()->getContents(), true);
+
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $response   = $e->getResponse();
+            $statusCode = $response->getStatusCode();
+            $jsonObject = json_decode($response->getBody()->getContents(), true);
+            $jsonObject['code'] = $statusCode;
+            throw new \Exception(json_encode($jsonObject));
+        }
+    }
+
+    private function provider()
+    {
+        if ($this->currentProvider === null) {
+            $this->currentProvider = new Providers\VerifyMyAgeV3Provider([
+                'clientId'     => $this->clientID,
+                'clientSecret' => $this->clientSecret,
+            ]);
+        }
+        return $this->currentProvider;
+    }
+}

--- a/src/Providers/VerifyMyAgeV3Provider.php
+++ b/src/Providers/VerifyMyAgeV3Provider.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace VerifyMyAge\Providers;
+
+class VerifyMyAgeV3Provider
+{
+    private $baseURL = "https://oauth.verifymyage.com";
+
+    private $clientId;
+
+    private $clientSecret;
+
+    public function __construct(array $options)
+    {
+        $this->clientId     = $options['clientId'];
+        $this->clientSecret = $options['clientSecret'];
+    }
+
+    public function useSandbox()
+    {
+        $this->baseURL = "https://oauth.sandbox.verifymyage.com";
+    }
+
+    public function getStartVerificationUrl()
+    {
+        return "{$this->baseURL}/api/v3/verifications";
+    }
+
+    public function getVerificationUrl(string $verificationId)
+    {
+        return "{$this->baseURL}/api/v3/verifications/{$verificationId}";
+    }
+
+    public function getAllowedRedirectsUrl()
+    {
+        return "{$this->baseURL}/api/v3/allowed-redirects";
+    }
+
+    /**
+     * HMAC authorization for POST/PUT requests (signs the request body).
+     */
+    public function generateHMACAuthorization(string $body)
+    {
+        $signature = hash_hmac('sha256', $body, $this->clientSecret);
+        return "hmac {$this->clientId}:{$signature}";
+    }
+
+    /**
+     * HMAC authorization for GET requests (signs the request URI path).
+     */
+    public function generateHMACAuthorizationForGet(string $uriPath)
+    {
+        $signature = hash_hmac('sha256', $uriPath, $this->clientSecret);
+        return "hmac {$this->clientId}:{$signature}";
+    }
+
+    public function getUserInfoEncoded(array $userInfo)
+    {
+        $userInfo['email'] = $this->encrypt($userInfo['email']);
+        return $userInfo;
+    }
+
+    private function encrypt(string $text)
+    {
+        $secretHash        = substr(hash('sha256', $this->clientSecret, true), 0, 32);
+        $iv                = openssl_random_pseudo_bytes(16);
+        $ciphertext        = openssl_encrypt($text, 'AES-256-CFB', $secretHash, OPENSSL_RAW_DATA, $iv);
+        return base64_encode($iv . $ciphertext);
+    }
+}

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -5,5 +5,6 @@ namespace VerifyMyAge;
 class Webhook {
     const MINIMAL_NOTIFICATION_LEVEL = "minimal";
     const METHOD_EXHAUSTED_NOTIFICATION_LEVEL = "method_exhausted";
+    const METHOD_EXHAUSTED_V3_NOTIFICATION_LEVEL = "method-exhausted";
     const DETAILED_NOTIFICATION_LEVEL = "detailed";
 }


### PR DESCRIPTION
Implements the /api/v3/verifications endpoints as a new OAuthV3 class with direct HMAC authentication, replacing the OAuth2 code-exchange flow. Adds getVerification(), getAllowedRedirects(), and addAllowedRedirects() methods. Extends Methods with DoubleBlind, and Webhook with the v3 method-exhausted level. Bumps SDK to 3.2.0.